### PR TITLE
Add RPC fallback verification to fix connection failures while calling  ``if web3.is_connected()``on Gensyn Testnet

### DIFF
--- a/src/genrl/blockchain/connections.py
+++ b/src/genrl/blockchain/connections.py
@@ -34,7 +34,11 @@ def setup_web3(url: str) -> Web3:
     if web3.is_connected():
         logger.info("✅ Connected to Gensyn Testnet")
     else:
-        raise Exception("Failed to connect to Gensyn Testnet")
+        try:
+            web3.eth.block_number
+            logger.info("✅ Connected to Gensyn Testnet")
+        except Exception:
+            raise Exception("Failed to connect to Gensyn Testnet")
     return web3
 
 


### PR DESCRIPTION
Adds fallback connection verification to handle cases where the standard connection check may return false on certain RPC provider configurations, ensuring more reliable connectivity to the Gensyn Testnet.

so i am attaching the main error log here:

<img width="1274" height="820" alt="image" src="https://github.com/user-attachments/assets/e5673564-b16a-4f65-85ad-da37d99b9deb" />

When connecting to Gensyn Testnet using the official public RPC endpoint (`https://gensyn-testnet.g.alchemy.com/public`), the `web3.is_connected()` method returns `False` due to restricted `web3_clientVersion` access, causing the connection to fail even though the blockchain is fully accessible.

**Reference:** [rl-swarm-contracts deployment config](https://github.com/gensyn-ai/rl-swarm-contracts/blob/master/README.md#L316)

## Solution
Added a fallback verification in `genrl/blockchain/connections.py` that uses `eth.block_number` when `web3.is_connected()` fails. 

The log demonstrates:
- `web3_clientVersion` fails with HTTP 401
- Fallback `eth_blockNumber` query succeeds
- Connection established successfully to Gensyn Testnet

<img width="1592" height="840" alt="image_2025-11-19_16-21-54" src="https://github.com/user-attachments/assets/419c3731-be0e-419c-89cc-2e175f5fbda2" />

i am attching here the screenshot of swarm_launcher.log after running the node with block_number method through the contract endpoint directly:

<img width="1919" height="912" alt="image" src="https://github.com/user-attachments/assets/93b73025-a28b-4564-a563-b2ba9b86dfcf" />
<img width="1913" height="913" alt="image_2025-11-19_15-28-16" src="https://github.com/user-attachments/assets/7e30d901-7b2c-4c5f-9261-c15d6c7f30dc" />


@jcd496 kindly look into this issue.

